### PR TITLE
Bump orjson version to 3.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-singer-python",
       install_requires=[
           'pytz',
           'jsonschema==3.2.0',
-          'orjson==3.7.2',
+          'orjson==3.8.0',
           'python-dateutil>=2.6.0',
           'backoff==2.1.2',
           'ciso8601',


### PR DESCRIPTION
# Description of change
See SM-3327

# Manual QA steps
 - Have run a modified version of s7clarke/pipelinewise-tap-oracle pointing at this branch in the `setup.py` file
 - Singer.decimal type values in the Oracle extract compare favourably with the source data and are held in the RECORD messages as strings as expected
  
# Rollback steps
 - revert this branch
