### PR TITLE
Bugfix: output decimal.Decimal as number not string to comply with JSONSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2 (2022-03-23)
+ * Using orjson instead of simplejson or other serializers for speed benefit
+ * Fix: Output decimal.Decimal as int or float not str
+
 ## 2.0.1 (2021-11-23)
   * Fixed an issue when `format_message` returned newline character
 

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -295,7 +295,7 @@ def parse_message(msg):
 def format_message(message, option=0):
     def default(obj):
         if isinstance(obj, decimal.Decimal):
-            return str(obj)
+            return int(obj) if float(obj).is_integer() else float(obj)
         raise TypeError
     
     return orjson.dumps(message.asdict(), option=option, default=default)


### PR DESCRIPTION
# Description of change
Bugfix: Previously the orjson 'default' handler function set `decimal.Decimal` types to str, which caused issues with targets that validate JSONSchema strictly. For example target-postgres uses JSONSchema validation, for which number as str is not allowed.

# Manual QA steps
 - Tested in local environment with different values for `decimal.Decimal` records
 
# Risks
 - Existing taps built on top of this variant will see a change to types in some record messages which could have unexpected results
 
# Rollback steps
 - revert this branch